### PR TITLE
geom_alt props

### DIFF
--- a/data/856/324/43/85632443.geojson
+++ b/data/856/324/43/85632443.geojson
@@ -893,6 +893,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -948,6 +949,11 @@
     },
     "wof:country":"SR",
     "wof:country_alpha3":"SUR",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"6a150f273593d93dacc5fbbcd9cb63d8",
     "wof:hierarchy":[
         {
@@ -962,7 +968,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649834,
+    "wof:lastmodified":1582326694,
     "wof:name":"Suriname",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/324/43/85632443.geojson
+++ b/data/856/324/43/85632443.geojson
@@ -893,7 +893,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -968,7 +967,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1582326694,
+    "wof:lastmodified":1583210427,
     "wof:name":"Suriname",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/773/07/85677307.geojson
+++ b/data/856/773/07/85677307.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Nickerie District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0487cb8b7a7e78ddc8d9b20cc2eb038",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649836,
+    "wof:lastmodified":1582326695,
     "wof:name":"Nickerie",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/13/85677313.geojson
+++ b/data/856/773/13/85677313.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Brokopondo District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5f69157de767b6125015f4c36e1f174",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649838,
+    "wof:lastmodified":1582326696,
     "wof:name":"Brokopondo",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/17/85677317.geojson
+++ b/data/856/773/17/85677317.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Marowijne District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b324044576f6527be52e68078cb96ecc",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649836,
+    "wof:lastmodified":1582326695,
     "wof:name":"Marowijne",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/19/85677319.geojson
+++ b/data/856/773/19/85677319.geojson
@@ -269,6 +269,9 @@
         "wk:page":"Para District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5477edac9098207067b9fa0a5dc65be1",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649836,
+    "wof:lastmodified":1582326695,
     "wof:name":"Para",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/23/85677323.geojson
+++ b/data/856/773/23/85677323.geojson
@@ -266,6 +266,9 @@
         "wk:page":"Sipaliwini District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ce900088b3c3d7ab6d0ee7ac87f2aa4",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649837,
+    "wof:lastmodified":1582326695,
     "wof:name":"Sipaliwini",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/29/85677329.geojson
+++ b/data/856/773/29/85677329.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Commewijne District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5eafd1343ebcf6eb4585a19740cd3a22",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649836,
+    "wof:lastmodified":1582326694,
     "wof:name":"Commewijne",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/33/85677333.geojson
+++ b/data/856/773/33/85677333.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Coronie District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6eb06d1e96c497495e4832dafbf164f5",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649835,
+    "wof:lastmodified":1582326694,
     "wof:name":"Coronie",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/37/85677337.geojson
+++ b/data/856/773/37/85677337.geojson
@@ -239,6 +239,9 @@
         890444597
     ],
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"008cd3c158252c006c5a151836691ef2",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649836,
+    "wof:lastmodified":1582326695,
     "wof:name":"Paramaribo",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/41/85677341.geojson
+++ b/data/856/773/41/85677341.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Saramacca District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57f9294ecea65b7013568f4429579ebb",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649837,
+    "wof:lastmodified":1582326695,
     "wof:name":"Saramacca",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/47/85677347.geojson
+++ b/data/856/773/47/85677347.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Wanica District"
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51b21c097b1ce397fc68105e6ea2efe9",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1566649838,
+    "wof:lastmodified":1582326696,
     "wof:name":"Wanica",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/857/648/65/85764865.geojson
+++ b/data/857/648/65/85764865.geojson
@@ -73,6 +73,9 @@
         "qs:id":1165369
     },
     "wof:country":"SR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68dc7cfd3da8fc4087255924280745e4",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1534379462,
+    "wof:lastmodified":1582326693,
     "wof:name":"Zorg en Hoop",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/444/597/890444597.geojson
+++ b/data/890/444/597/890444597.geojson
@@ -525,6 +525,10 @@
     ],
     "wof:country":"SR",
     "wof:created":1469052475,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c842bcb7a9deddb50bf18e9d6ddc5c58",
     "wof:hierarchy":[
         {
@@ -536,7 +540,7 @@
         }
     ],
     "wof:id":890444597,
-    "wof:lastmodified":1566649882,
+    "wof:lastmodified":1582326697,
     "wof:name":"Paramaribo",
     "wof:parent_id":1091712961,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.