### PR TITLE
Name updates

### DIFF
--- a/data/856/324/43/85632443.geojson
+++ b/data/856/324/43/85632443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.879502,
-    "geom:area_square_m":146485776078.345673,
+    "geom:area_square_m":146485775254.710205,
     "geom:bbox":"-58.070506,1.837306,-53.978763,6.016639",
     "geom:latitude":4.139468,
     "geom:longitude":-55.906476,
@@ -43,11 +43,17 @@
     "name:amh_x_preferred":[
         "\u1231\u122a\u1293\u121d"
     ],
+    "name:ang_x_preferred":[
+        "Suriname"
+    ],
     "name:ara_x_preferred":[
         "\u0633\u0648\u0631\u064a\u0646\u0627\u0645"
     ],
     "name:arg_x_preferred":[
         "Surinam"
+    ],
+    "name:ary_x_preferred":[
+        "\u0633\u0648\u0631\u064a\u0646\u0627\u0645"
     ],
     "name:arz_x_preferred":[
         "\u0633\u0648\u0631\u064a\u0646\u0627\u0645"
@@ -72,6 +78,9 @@
     ],
     "name:bam_x_preferred":[
         "Surinami"
+    ],
+    "name:ban_x_preferred":[
+        "Suriname"
     ],
     "name:bar_x_preferred":[
         "Suriname"
@@ -148,6 +157,12 @@
     "name:dan_x_preferred":[
         "Surinam"
     ],
+    "name:deu_at_x_preferred":[
+        "Suriname"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Suriname"
+    ],
     "name:deu_x_preferred":[
         "Suriname"
     ],
@@ -165,6 +180,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03bf\u03c5\u03c1\u03b9\u03bd\u03ac\u03bc"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Suriname"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Suriname"
     ],
     "name:eng_x_preferred":[
         "Suriname"
@@ -233,6 +254,9 @@
     "name:gag_x_preferred":[
         "Surinam"
     ],
+    "name:gcr_x_preferred":[
+        "Sourinanm"
+    ],
     "name:ger_x_variant":[
         "Republik Suriname"
     ],
@@ -253,6 +277,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0938\u0942\u0930\u0940\u0928\u093e\u092e"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf43\ud800\udf3f\ud800\udf42\ud800\udf39\ud800\udf3d\ud800\udf30\ud800\udf3c\ud800\udf30"
     ],
     "name:grn_x_preferred":[
         "Surin\u00e3"
@@ -425,6 +452,9 @@
     "name:ltz_x_preferred":[
         "Suriname"
     ],
+    "name:ltz_x_variant":[
+        "Surinam"
+    ],
     "name:lub_x_preferred":[
         "Suriname"
     ],
@@ -569,6 +599,9 @@
     "name:pol_x_preferred":[
         "Surinam"
     ],
+    "name:por_br_x_preferred":[
+        "Suriname"
+    ],
     "name:por_x_preferred":[
         "Suriname"
     ],
@@ -605,6 +638,9 @@
     "name:san_x_preferred":[
         "\u0938\u0941\u0930\u093f\u0928\u093e\u092e"
     ],
+    "name:sat_x_preferred":[
+        "\u1c65\u1c69\u1c68\u1c64\u1c71\u1c6e\u1c62"
+    ],
     "name:scn_x_preferred":[
         "Surinami"
     ],
@@ -635,6 +671,9 @@
     "name:sna_x_preferred":[
         "Suriname"
     ],
+    "name:snd_x_preferred":[
+        "\u0633\u0648\u0631\u064a\u0646\u0627\u0645"
+    ],
     "name:som_x_preferred":[
         "Surinam"
     ],
@@ -652,6 +691,12 @@
     ],
     "name:srn_x_preferred":[
         "Sranankondre"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0421\u0443\u0440\u0438\u043d\u0430\u043c"
+    ],
+    "name:srp_el_x_preferred":[
+        "Surinam"
     ],
     "name:srp_x_preferred":[
         "\u0421\u0443\u0440\u0438\u043d\u0430\u043c"
@@ -676,6 +721,9 @@
     ],
     "name:szl_x_preferred":[
         "Surinam"
+    ],
+    "name:szy_x_preferred":[
+        "Suriname"
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc1\u0bb0\u0bbf\u0ba8\u0bbe\u0bae\u0bcd"
@@ -803,8 +851,26 @@
     "name:zha_x_preferred":[
         "Suriname"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u82cf\u91cc\u5357"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8607\u91cc\u5357"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Suriname"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u8607\u91cc\u5357"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u82cf\u91cc\u5357"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u82cf\u91cc\u5357"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u8607\u5229\u5357"
     ],
     "name:zho_x_preferred":[
         "\u8607\u5229\u5357"
@@ -968,7 +1034,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1583797434,
+    "wof:lastmodified":1587427957,
     "wof:name":"Suriname",
     "wof:parent_id":102191577,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.