### PR TITLE
sr concordances, placetype local, and more

### DIFF
--- a/data/109/171/122/5/1091711225.geojson
+++ b/data/109/171/122/5/1091711225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.067115,
-    "geom:area_square_m":25483996450.725571,
+    "geom:area_square_m":25483996493.475163,
     "geom:bbox":"-58.070506,3.26213,-56.238165,5.351273",
     "geom:latitude":4.395304,
     "geom:longitude":-57.224883,
@@ -105,9 +105,10 @@
         "hasc:id":"SR.SI.KA",
         "wd:id":"Q2359770"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880212,
-    "wof:geomhash":"2f35aac3a3026f69ea7b00fe4c3b9fe6",
+    "wof:geomhash":"00dd49ed6d474c4813fe7e8569c0667a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091711225,
-    "wof:lastmodified":1636496743,
+    "wof:lastmodified":1695886730,
     "wof:name":"Kabalebo",
     "wof:parent_id":85677323,
     "wof:placetype":"county",

--- a/data/109/171/127/1/1091711271.geojson
+++ b/data/109/171/127/1/1091711271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.371215,
-    "geom:area_square_m":4575533558.681491,
+    "geom:area_square_m":4575533391.214795,
     "geom:bbox":"-55.37804,4.014834,-54.728048,5.005289",
     "geom:latitude":4.567195,
     "geom:longitude":-55.060725,
@@ -87,9 +87,10 @@
         "hasc:id":"SR.BR.SK",
         "wd:id":"Q2398165"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880214,
-    "wof:geomhash":"14d541c2eb183080a7bbb31a6f2fbdae",
+    "wof:geomhash":"d7675f501989a5c11c61c9e1875248e9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091711271,
-    "wof:lastmodified":1690866699,
+    "wof:lastmodified":1695886426,
     "wof:name":"Sarakreek",
     "wof:parent_id":85677313,
     "wof:placetype":"county",

--- a/data/109/171/130/3/1091711303.geojson
+++ b/data/109/171/130/3/1091711303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.461879,
-    "geom:area_square_m":5694746120.676147,
+    "geom:area_square_m":5694745878.20467,
     "geom:bbox":"-56.212972,3.518305,-55.296082,5.105809",
     "geom:latitude":4.335289,
     "geom:longitude":-55.782168,
@@ -87,9 +87,10 @@
         "hasc:id":"SR.SI.BV",
         "wd:id":"Q1983065"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880215,
-    "wof:geomhash":"08c787c684ae8b695e079425da4f5b08",
+    "wof:geomhash":"b1712568fd0c26791f31ce93f6e6a031",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091711303,
-    "wof:lastmodified":1690866701,
+    "wof:lastmodified":1695886729,
     "wof:name":"Saramacca",
     "wof:parent_id":85677323,
     "wof:placetype":"county",

--- a/data/109/171/135/3/1091711353.geojson
+++ b/data/109/171/135/3/1091711353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038808,
-    "geom:area_square_m":477628498.146905,
+    "geom:area_square_m":477628674.569601,
     "geom:bbox":"-54.227662,5.346913,-53.997085,5.656377",
     "geom:latitude":5.53173,
     "geom:longitude":-54.104593,
@@ -147,9 +147,10 @@
         "hasc:id":"SR.MA.AB",
         "wd:id":"Q580016"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880217,
-    "wof:geomhash":"e4d18619dd802f6692d90640c90b8f54",
+    "wof:geomhash":"c637a4a2018fe05bff9129378b4a25bf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1091711353,
-    "wof:lastmodified":1690866693,
+    "wof:lastmodified":1695886425,
     "wof:name":"Albina",
     "wof:parent_id":85677317,
     "wof:placetype":"county",

--- a/data/109/171/140/9/1091711409.geojson
+++ b/data/109/171/140/9/1091711409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037225,
-    "geom:area_square_m":457829457.228237,
+    "geom:area_square_m":457829022.242742,
     "geom:bbox":"-55.020912,5.840547,-54.698842,6.00751",
     "geom:latitude":5.928537,
     "geom:longitude":-54.848371,
@@ -84,9 +84,10 @@
         "hasc:id":"SR.CM.BK",
         "wd:id":"Q1757308"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880219,
-    "wof:geomhash":"c6fb9681ac774177c9392e60fd77e4de",
+    "wof:geomhash":"e4bc40a89afa09d783c6f43b28ae68e4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091711409,
-    "wof:lastmodified":1690866705,
+    "wof:lastmodified":1695886428,
     "wof:name":"Bakki",
     "wof:parent_id":85677329,
     "wof:placetype":"county",

--- a/data/109/171/144/3/1091711443.geojson
+++ b/data/109/171/144/3/1091711443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117154,
-    "geom:area_square_m":1441513723.915643,
+    "geom:area_square_m":1441513575.122354,
     "geom:bbox":"-56.603132,5.337658,-56.34722,5.955738",
     "geom:latitude":5.681224,
     "geom:longitude":-56.463945,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.CR.JM",
         "wd:id":"Q1757548"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880220,
-    "wof:geomhash":"caef9f13f8d529e524ab7281bbc711f0",
+    "wof:geomhash":"442ed506af3cac62bf8271222033a00d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091711443,
-    "wof:lastmodified":1690866699,
+    "wof:lastmodified":1695886427,
     "wof:name":"Johanna Maria",
     "wof:parent_id":85677333,
     "wof:placetype":"county",

--- a/data/109/171/148/5/1091711485.geojson
+++ b/data/109/171/148/5/1091711485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025445,
-    "geom:area_square_m":312948945.16443,
+    "geom:area_square_m":312948618.565809,
     "geom:bbox":"-57.011391,5.826096,-56.763941,6.006778",
     "geom:latitude":5.932842,
     "geom:longitude":-56.899024,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.NI.OP",
         "wd:id":"Q1757504"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880221,
-    "wof:geomhash":"69a06e13775d0757849ee13a1c0d9a74",
+    "wof:geomhash":"2bf5ef86f6fd63052cfbb9cbf595ec2a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091711485,
-    "wof:lastmodified":1690866705,
+    "wof:lastmodified":1695886485,
     "wof:name":"Oostelijke Polders",
     "wof:parent_id":85677307,
     "wof:placetype":"county",

--- a/data/109/171/153/5/1091711535.geojson
+++ b/data/109/171/153/5/1091711535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133582,
-    "geom:area_square_m":1643835688.052603,
+    "geom:area_square_m":1643835614.170151,
     "geom:bbox":"-56.810848,5.325056,-56.453003,5.974583",
     "geom:latitude":5.616366,
     "geom:longitude":-56.657465,
@@ -120,9 +120,10 @@
         "hasc:id":"SR.NI.WN",
         "wd:id":"Q24224"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880223,
-    "wof:geomhash":"894910540b14d7dcc87402b07d9f99e1",
+    "wof:geomhash":"7be94493d1d4bd853b2fab57734c0c8f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091711535,
-    "wof:lastmodified":1690866700,
+    "wof:lastmodified":1695886427,
     "wof:name":"Wageningen",
     "wof:parent_id":85677307,
     "wof:placetype":"county",

--- a/data/109/171/157/7/1091711577.geojson
+++ b/data/109/171/157/7/1091711577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07362,
-    "geom:area_square_m":905476035.38178,
+    "geom:area_square_m":905475907.824829,
     "geom:bbox":"-55.962944,5.826603,-55.298017,5.999306",
     "geom:latitude":5.918922,
     "geom:longitude":-55.601685,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.SA.WY",
         "wd:id":"Q1757266"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880224,
-    "wof:geomhash":"94440efa17d5d421533320d665ad3a40",
+    "wof:geomhash":"8c7d671adc7edc53f23e61620fcb9c82",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091711577,
-    "wof:lastmodified":1690866693,
+    "wof:lastmodified":1695886485,
     "wof:name":"Wayamboweg",
     "wof:parent_id":85677341,
     "wof:placetype":"county",

--- a/data/109/171/162/1/1091711621.geojson
+++ b/data/109/171/162/1/1091711621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06004,
-    "geom:area_square_m":738848464.423962,
+    "geom:area_square_m":738848191.155024,
     "geom:bbox":"-55.608842,5.440005,-55.325898,5.795171",
     "geom:latitude":5.612441,
     "geom:longitude":-55.467506,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.SA.KB",
         "wd:id":"Q1757510"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880226,
-    "wof:geomhash":"11403da01a12684355fc82703476d726",
+    "wof:geomhash":"953295aa9cab949bfeca80b6ac93c3a2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091711621,
-    "wof:lastmodified":1690866700,
+    "wof:lastmodified":1695886485,
     "wof:name":"Kampong Baroe",
     "wof:parent_id":85677341,
     "wof:placetype":"county",

--- a/data/109/171/166/3/1091711663.geojson
+++ b/data/109/171/166/3/1091711663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207707,
-    "geom:area_square_m":2557484451.252079,
+    "geom:area_square_m":2557484383.463986,
     "geom:bbox":"-56.045398,5.008983,-55.341336,5.544976",
     "geom:latitude":5.267691,
     "geom:longitude":-55.68331,
@@ -93,9 +93,10 @@
         "hasc:id":"SR.PR.BP",
         "wd:id":"Q859684"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880228,
-    "wof:geomhash":"033dfdfb178158f4f6d9d9fb21ec770f",
+    "wof:geomhash":"59d07d879a09ebcfd0b0a5fad550a192",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091711663,
-    "wof:lastmodified":1690866694,
+    "wof:lastmodified":1695886425,
     "wof:name":"Bigi Poika",
     "wof:parent_id":85677319,
     "wof:placetype":"county",

--- a/data/109/171/170/7/1091711707.geojson
+++ b/data/109/171/170/7/1091711707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111395,
-    "geom:area_square_m":1371456844.18487,
+    "geom:area_square_m":1371456596.952896,
     "geom:bbox":"-55.016912,4.99462,-54.623314,5.549248",
     "geom:latitude":5.333241,
     "geom:longitude":-54.825854,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.PR.CR",
         "wd:id":"Q1757542"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880229,
-    "wof:geomhash":"73a9f2dd0e0e05463c2521c4e8ec6711",
+    "wof:geomhash":"194431d6bd836ec06e9bad805e7f6a14",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091711707,
-    "wof:lastmodified":1690866704,
+    "wof:lastmodified":1695886483,
     "wof:name":"Carolina",
     "wof:parent_id":85677319,
     "wof:placetype":"county",

--- a/data/109/171/173/3/1091711733.geojson
+++ b/data/109/171/173/3/1091711733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024955,
-    "geom:area_square_m":307362541.792681,
+    "geom:area_square_m":307362494.10304,
     "geom:bbox":"-55.074113,4.987154,-54.867762,5.163365",
     "geom:latitude":5.075503,
     "geom:longitude":-54.957724,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"SR.BR.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880230,
-    "wof:geomhash":"750c6701a14622d99acbfc73419be26c",
+    "wof:geomhash":"1739a385fb0b8f91b58d503c258ba88e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091711733,
-    "wof:lastmodified":1627522788,
+    "wof:lastmodified":1695886483,
     "wof:name":"Centrum",
     "wof:parent_id":85677313,
     "wof:placetype":"county",

--- a/data/109/171/177/7/1091711777.geojson
+++ b/data/109/171/177/7/1091711777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010419,
-    "geom:area_square_m":128172943.866251,
+    "geom:area_square_m":128173229.908442,
     "geom:bbox":"-55.478272,5.767657,-55.302749,5.849852",
     "geom:latitude":5.810109,
     "geom:longitude":-55.382895,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.SA.JK",
         "wd:id":"Q1757522"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880232,
-    "wof:geomhash":"6183f3a398f983418374c005ee98caaa",
+    "wof:geomhash":"ee0f98a65717f7b47ea170a5e560320d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091711777,
-    "wof:lastmodified":1690866705,
+    "wof:lastmodified":1695886485,
     "wof:name":"Jarikaba",
     "wof:parent_id":85677341,
     "wof:placetype":"county",

--- a/data/109/171/180/3/1091711803.geojson
+++ b/data/109/171/180/3/1091711803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012194,
-    "geom:area_square_m":150038956.157219,
+    "geom:area_square_m":150039263.73554,
     "geom:bbox":"-55.357816,5.659633,-55.180334,5.755289",
     "geom:latitude":5.705392,
     "geom:longitude":-55.274272,
@@ -147,9 +147,10 @@
         "hasc:id":"SR.WA.LD",
         "wd:id":"Q935545"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880233,
-    "wof:geomhash":"8b8fd984eb0a377195d92e5163a4f4c1",
+    "wof:geomhash":"445959cae2818e065e8c14473c4948d0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1091711803,
-    "wof:lastmodified":1690866698,
+    "wof:lastmodified":1695886427,
     "wof:name":"Lelydorp",
     "wof:parent_id":85677347,
     "wof:placetype":"county",

--- a/data/109/171/180/5/1091711805.geojson
+++ b/data/109/171/180/5/1091711805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004545,
-    "geom:area_square_m":55913206.953967,
+    "geom:area_square_m":55913020.725587,
     "geom:bbox":"-55.197606,5.687883,-55.129801,5.788215",
     "geom:latitude":5.737408,
     "geom:longitude":-55.164795,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.WA.HO",
         "wd:id":"Q5648548"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880235,
-    "wof:geomhash":"e7571d8aa7cabf99705b3ac6d87c9974",
+    "wof:geomhash":"2534838e161bbc32e729f38dbaf7b2ff",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091711805,
-    "wof:lastmodified":1690866698,
+    "wof:lastmodified":1695886427,
     "wof:name":"Houttuin",
     "wof:parent_id":85677347,
     "wof:placetype":"county",

--- a/data/109/171/180/7/1091711807.geojson
+++ b/data/109/171/180/7/1091711807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028123,
-    "geom:area_square_m":346318969.109495,
+    "geom:area_square_m":346319021.897079,
     "geom:bbox":"-55.276941,5.128008,-54.898892,5.232673",
     "geom:latitude":5.182366,
     "geom:longitude":-55.111754,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.BR.KK",
         "wd:id":"Q2743532"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880236,
-    "wof:geomhash":"ea8a45f95d829272c49889eab44b2d91",
+    "wof:geomhash":"71cb86f3d76f94af60eefb10c8894db7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091711807,
-    "wof:lastmodified":1690866698,
+    "wof:lastmodified":1695886427,
     "wof:name":"Klaaskreek",
     "wof:parent_id":85677313,
     "wof:placetype":"county",

--- a/data/109/171/181/3/1091711813.geojson
+++ b/data/109/171/181/3/1091711813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031141,
-    "geom:area_square_m":383429037.223864,
+    "geom:area_square_m":383429166.248934,
     "geom:bbox":"-55.248388,5.229413,-54.946805,5.367643",
     "geom:latitude":5.288887,
     "geom:longitude":-55.100778,
@@ -102,9 +102,10 @@
         "hasc:id":"SR.BR.MK",
         "wd:id":"Q2108036"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880238,
-    "wof:geomhash":"6760754bfb9e635d316c0551348ea753",
+    "wof:geomhash":"408dab26fed9d34f823e88c2321c6752",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091711813,
-    "wof:lastmodified":1690866699,
+    "wof:lastmodified":1695886427,
     "wof:name":"Marchalkreek",
     "wof:parent_id":85677313,
     "wof:placetype":"county",

--- a/data/109/171/186/5/1091711865.geojson
+++ b/data/109/171/186/5/1091711865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006814,
-    "geom:area_square_m":83820149.57283,
+    "geom:area_square_m":83820087.114295,
     "geom:bbox":"-55.069717,5.799768,-54.941455,5.886713",
     "geom:latitude":5.845872,
     "geom:longitude":-55.016592,
@@ -93,9 +93,10 @@
         "hasc:id":"SR.CM.AM",
         "wd:id":"Q1757278"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880239,
-    "wof:geomhash":"6e90d2d820ff73c76542bce29e028792",
+    "wof:geomhash":"d3ae1336e14dd067e03dfc796693a2f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091711865,
-    "wof:lastmodified":1690866699,
+    "wof:lastmodified":1695886427,
     "wof:name":"Alkmaar",
     "wof:parent_id":85677329,
     "wof:placetype":"county",

--- a/data/109/171/191/1/1091711911.geojson
+++ b/data/109/171/191/1/1091711911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005198,
-    "geom:area_square_m":63939619.282755,
+    "geom:area_square_m":63939629.595195,
     "geom:bbox":"-55.309867,5.831112,-55.233503,5.945942",
     "geom:latitude":5.887118,
     "geom:longitude":-55.278192,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.WA.KT",
         "wd:id":"Q1757289"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880241,
-    "wof:geomhash":"ca45013c6fce09392a79c37d5af1bb3a",
+    "wof:geomhash":"588453091082cbb11bf9021027a30ddc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091711911,
-    "wof:lastmodified":1690866700,
+    "wof:lastmodified":1695886485,
     "wof:name":"Kwatta",
     "wof:parent_id":85677347,
     "wof:placetype":"county",

--- a/data/109/171/195/9/1091711959.geojson
+++ b/data/109/171/195/9/1091711959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093712,
-    "geom:area_square_m":1153184109.949494,
+    "geom:area_square_m":1153184020.335029,
     "geom:bbox":"-55.157112,5.485897,-54.621101,5.828722",
     "geom:latitude":5.627469,
     "geom:longitude":-54.889113,
@@ -111,9 +111,10 @@
         "hasc:id":"SR.CM.MZ",
         "wd:id":"Q1018882"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880243,
-    "wof:geomhash":"84878c53b1c669466fc8947ec85cc625",
+    "wof:geomhash":"d977ec4555bf802a9d00c9204112b42b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091711959,
-    "wof:lastmodified":1690866694,
+    "wof:lastmodified":1695886426,
     "wof:name":"Meerzorg",
     "wof:parent_id":85677329,
     "wof:placetype":"county",

--- a/data/109/171/200/7/1091712007.geojson
+++ b/data/109/171/200/7/1091712007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089712,
-    "geom:area_square_m":1103823737.248838,
+    "geom:area_square_m":1103823585.533752,
     "geom:bbox":"-54.734963,5.491355,-54.315938,5.902647",
     "geom:latitude":5.697075,
     "geom:longitude":-54.533749,
@@ -165,9 +165,10 @@
         "hasc:id":"SR.MA.MO",
         "wd:id":"Q24226"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880244,
-    "wof:geomhash":"0920479d062f6b506cb4f4ebc8c7babf",
+    "wof:geomhash":"3c83c0285396df5782d2c4ef6e4baebe",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":1091712007,
-    "wof:lastmodified":1690866702,
+    "wof:lastmodified":1695886730,
     "wof:name":"Moengo",
     "wof:parent_id":85677317,
     "wof:placetype":"county",

--- a/data/109/171/205/3/1091712053.geojson
+++ b/data/109/171/205/3/1091712053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082485,
-    "geom:area_square_m":1014691663.067204,
+    "geom:area_square_m":1014691812.373075,
     "geom:bbox":"-54.711453,5.623873,-53.982887,5.979249",
     "geom:latitude":5.813622,
     "geom:longitude":-54.26203,
@@ -87,9 +87,10 @@
         "hasc:id":"SR.MA.GB",
         "wd:id":"Q2554506"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880246,
-    "wof:geomhash":"0cb407482a66fe6f1e966fef0461bd94",
+    "wof:geomhash":"2f616e969d52a7a6907d3fc8eb0340a1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091712053,
-    "wof:lastmodified":1690866697,
+    "wof:lastmodified":1695886426,
     "wof:name":"Galibi",
     "wof:parent_id":85677317,
     "wof:placetype":"county",

--- a/data/109/171/209/1/1091712091.geojson
+++ b/data/109/171/209/1/1091712091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002523,
-    "geom:area_square_m":31030804.310521,
+    "geom:area_square_m":31030798.358546,
     "geom:bbox":"-55.121103,5.798686,-55.06074,5.876846",
     "geom:latitude":5.835275,
     "geom:longitude":-55.086445,
@@ -153,9 +153,10 @@
         "hasc:id":"SR.CM.NA",
         "wd:id":"Q762619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880248,
-    "wof:geomhash":"70ac0ea05d02f2baf600568ee4703a21",
+    "wof:geomhash":"3e66c0543e715a6f9729127b58a6116c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1091712091,
-    "wof:lastmodified":1690866702,
+    "wof:lastmodified":1695886730,
     "wof:name":"Nieuw Amsterdam",
     "wof:parent_id":85677329,
     "wof:placetype":"county",

--- a/data/109/171/213/3/1091712133.geojson
+++ b/data/109/171/213/3/1091712133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03622,
-    "geom:area_square_m":445779312.909812,
+    "geom:area_square_m":445779447.837206,
     "geom:bbox":"-55.193997,5.344274,-54.98168,5.703869",
     "geom:latitude":5.529701,
     "geom:longitude":-55.079605,
@@ -84,9 +84,10 @@
         "hasc:id":"SR.PR.OS",
         "wd:id":"Q599769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880249,
-    "wof:geomhash":"bd6805273a2213b3edc9c6785bfded38",
+    "wof:geomhash":"e118af461360cf3256ff83042fa24741",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091712133,
-    "wof:lastmodified":1690866702,
+    "wof:lastmodified":1695886485,
     "wof:name":"Oost",
     "wof:parent_id":85677319,
     "wof:placetype":"county",

--- a/data/109/171/216/1/1091712161.geojson
+++ b/data/109/171/216/1/1091712161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002925,
-    "geom:area_square_m":35994103.402337,
+    "geom:area_square_m":35994097.360948,
     "geom:bbox":"-55.143102,5.676351,-55.077664,5.755541",
     "geom:latitude":5.70961,
     "geom:longitude":-55.112147,
@@ -126,9 +126,10 @@
         "hasc:id":"SR.WA.DO",
         "wd:id":"Q650018"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880251,
-    "wof:geomhash":"a73b42769ec589f5d5ddd8500cb3c599",
+    "wof:geomhash":"84b39193dbc039ecbee4d2b1aaa0f5de",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1091712161,
-    "wof:lastmodified":1690866694,
+    "wof:lastmodified":1695886426,
     "wof:name":"Domburg",
     "wof:parent_id":85677347,
     "wof:placetype":"county",

--- a/data/109/171/220/7/1091712207.geojson
+++ b/data/109/171/220/7/1091712207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083372,
-    "geom:area_square_m":1026879426.8084,
+    "geom:area_square_m":1026879522.761302,
     "geom:bbox":"-55.518358,4.768365,-55.218899,5.339348",
     "geom:latitude":5.063555,
     "geom:longitude":-55.355633,
@@ -90,9 +90,10 @@
         "hasc:id":"SR.BR.KW",
         "wd:id":"Q2564453"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880252,
-    "wof:geomhash":"6212e0d195227e7a19fd16b95aeac8f1",
+    "wof:geomhash":"246cc4216e5646737c1afb843de07a2c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091712207,
-    "wof:lastmodified":1690866695,
+    "wof:lastmodified":1695886426,
     "wof:name":"Kwakoegron",
     "wof:parent_id":85677313,
     "wof:placetype":"county",

--- a/data/109/171/225/5/1091712255.geojson
+++ b/data/109/171/225/5/1091712255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001786,
-    "geom:area_square_m":21968544.019083,
+    "geom:area_square_m":21968542.618544,
     "geom:bbox":"-55.307223,5.810994,-55.231714,5.850213",
     "geom:latitude":5.830093,
     "geom:longitude":-55.275294,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.WA.SP",
         "wd:id":"Q1934017"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880254,
-    "wof:geomhash":"fbe9780583922edb4cd846ce59d6f637",
+    "wof:geomhash":"9f8c6e2d3f44853937d1275641a9c038",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091712255,
-    "wof:lastmodified":1690866702,
+    "wof:lastmodified":1695886486,
     "wof:name":"Saramacca Polder",
     "wof:parent_id":85677347,
     "wof:placetype":"county",

--- a/data/109/171/228/7/1091712287.geojson
+++ b/data/109/171/228/7/1091712287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04123,
-    "geom:area_square_m":507223594.341629,
+    "geom:area_square_m":507223722.872759,
     "geom:bbox":"-55.034145,5.688189,-54.693247,5.891435",
     "geom:latitude":5.787802,
     "geom:longitude":-54.853111,
@@ -93,9 +93,10 @@
         "hasc:id":"SR.CM.TR",
         "wd:id":"Q2613286"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880255,
-    "wof:geomhash":"4878984578c6b4e27b462edca9a0d0cd",
+    "wof:geomhash":"3b6a140650a2c57d1c43df74a4e9c7b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091712287,
-    "wof:lastmodified":1690866696,
+    "wof:lastmodified":1695886426,
     "wof:name":"Tamanredjo",
     "wof:parent_id":85677329,
     "wof:placetype":"county",

--- a/data/109/171/233/3/1091712333.geojson
+++ b/data/109/171/233/3/1091712333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014304,
-    "geom:area_square_m":176015918.826892,
+    "geom:area_square_m":176015924.075586,
     "geom:bbox":"-56.368217,5.389467,-56.324708,5.91375",
     "geom:latitude":5.647637,
     "geom:longitude":-56.344353,
@@ -156,9 +156,10 @@
         "hasc:id":"SR.CR.TN",
         "wd:id":"Q1357920"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880257,
-    "wof:geomhash":"c1ad8191fa7cf7342cc39f6c5b846f82",
+    "wof:geomhash":"ccdd50cca15f6f9eb37897d34816737f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":1091712333,
-    "wof:lastmodified":1690866697,
+    "wof:lastmodified":1695886730,
     "wof:name":"Totness",
     "wof:parent_id":85677333,
     "wof:placetype":"county",

--- a/data/109/171/237/9/1091712379.geojson
+++ b/data/109/171/237/9/1091712379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004802,
-    "geom:area_square_m":59074747.204331,
+    "geom:area_square_m":59074594.052326,
     "geom:bbox":"-55.545916,5.738661,-55.458165,5.868648",
     "geom:latitude":5.807908,
     "geom:longitude":-55.496817,
@@ -150,9 +150,10 @@
         "hasc:id":"SR.SA.GG",
         "wd:id":"Q508935"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880258,
-    "wof:geomhash":"0cb10c5d936be665996b03c9e045fe5c",
+    "wof:geomhash":"b62727a272e72833b9103b9408d61f28",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1091712379,
-    "wof:lastmodified":1690866703,
+    "wof:lastmodified":1695886730,
     "wof:name":"Groningen",
     "wof:parent_id":85677341,
     "wof:placetype":"county",

--- a/data/109/171/242/3/1091712423.geojson
+++ b/data/109/171/242/3/1091712423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020832,
-    "geom:area_square_m":256286633.151128,
+    "geom:area_square_m":256286812.327074,
     "geom:bbox":"-55.641488,5.677775,-55.502077,5.872454",
     "geom:latitude":5.780528,
     "geom:longitude":-55.581272,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.SA.TK",
         "wd:id":"Q1757260"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880259,
-    "wof:geomhash":"23cde9d6a5c9b75940c54da30e6ee132",
+    "wof:geomhash":"37eb24f6c6801fb4dfe83315ddfd0291",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091712423,
-    "wof:lastmodified":1690866695,
+    "wof:lastmodified":1695886486,
     "wof:name":"Tijgerkreek",
     "wof:parent_id":85677341,
     "wof:placetype":"county",

--- a/data/109/171/246/7/1091712467.geojson
+++ b/data/109/171/246/7/1091712467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17442,
-    "geom:area_square_m":2146276012.388186,
+    "geom:area_square_m":2146276140.116798,
     "geom:bbox":"-56.33345,5.387026,-55.887085,5.908518",
     "geom:latitude":5.643757,
     "geom:longitude":-56.14473,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"SR.CR.WL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880261,
-    "wof:geomhash":"a95b86b9c926ee6a5ea57fbe5923b420",
+    "wof:geomhash":"ad76d03654ff67a370bfb63372ec0226",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091712467,
-    "wof:lastmodified":1627522790,
+    "wof:lastmodified":1695886486,
     "wof:name":"Welgelegen",
     "wof:parent_id":85677333,
     "wof:placetype":"county",

--- a/data/109/171/250/7/1091712507.geojson
+++ b/data/109/171/250/7/1091712507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002025,
-    "geom:area_square_m":24908658.020302,
+    "geom:area_square_m":24908615.33472,
     "geom:bbox":"-57.00899,5.899051,-56.968653,5.967511",
     "geom:latitude":5.930508,
     "geom:longitude":-56.988027,
@@ -156,9 +156,10 @@
         "hasc:id":"SR.NI.NN",
         "wd:id":"Q738313"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880263,
-    "wof:geomhash":"02962718f667800fd8083f4ae844e242",
+    "wof:geomhash":"9ec7844f908ea3cc650b8391e1b41bf4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":1091712507,
-    "wof:lastmodified":1690866697,
+    "wof:lastmodified":1695886730,
     "wof:name":"Nieuw Nickerie",
     "wof:parent_id":85677307,
     "wof:placetype":"county",

--- a/data/109/171/255/1/1091712551.geojson
+++ b/data/109/171/255/1/1091712551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086708,
-    "geom:area_square_m":1067031867.419747,
+    "geom:area_square_m":1067031871.868547,
     "geom:bbox":"-57.339381,5.220251,-56.982402,5.973778",
     "geom:latitude":5.603682,
     "geom:longitude":-57.142087,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.NI.WP",
         "wd:id":"Q512231"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880264,
-    "wof:geomhash":"dbe76fc4ed4a120bddc3965c1ee5a5b7",
+    "wof:geomhash":"0accf7af41aa682b34b6600f5b74ac50",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091712551,
-    "wof:lastmodified":1690866703,
+    "wof:lastmodified":1695886486,
     "wof:name":"Westelijke Polders",
     "wof:parent_id":85677307,
     "wof:placetype":"county",

--- a/data/109/171/257/7/1091712577.geojson
+++ b/data/109/171/257/7/1091712577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070785,
-    "geom:area_square_m":871294778.087541,
+    "geom:area_square_m":871294950.738245,
     "geom:bbox":"-55.471774,5.325283,-55.100537,5.611438",
     "geom:latitude":5.461617,
     "geom:longitude":-55.253924,
@@ -84,9 +84,10 @@
         "hasc:id":"SR.PR.ZD",
         "wd:id":"Q3147913"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880265,
-    "wof:geomhash":"0235749ee1a23e6f9174d4d80e760451",
+    "wof:geomhash":"9a45e7f651d97c238f503b0b936c8782",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091712577,
-    "wof:lastmodified":1690866696,
+    "wof:lastmodified":1695886486,
     "wof:name":"Zuid",
     "wof:parent_id":85677319,
     "wof:placetype":"county",

--- a/data/109/171/261/7/1091712617.geojson
+++ b/data/109/171/261/7/1091712617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100586,
-    "geom:area_square_m":1238233714.225516,
+    "geom:area_square_m":1238233515.570233,
     "geom:bbox":"-54.641695,5.227997,-54.152818,5.598821",
     "geom:latitude":5.404323,
     "geom:longitude":-54.422439,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.MA.PM",
         "wd:id":"Q1757294"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880267,
-    "wof:geomhash":"7d3aad9f83c9e46841b62efc7354041a",
+    "wof:geomhash":"501605f1ba4b4941a32c23097364d881",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091712617,
-    "wof:lastmodified":1690866697,
+    "wof:lastmodified":1695886426,
     "wof:name":"Patamacca",
     "wof:parent_id":85677317,
     "wof:placetype":"county",

--- a/data/109/171/265/5/1091712655.geojson
+++ b/data/109/171/265/5/1091712655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016469,
-    "geom:area_square_m":202660835.337735,
+    "geom:area_square_m":202660835.337743,
     "geom:bbox":"-55.3995723387,5.5604259345,-55.1833116649,5.67288933126",
     "geom:latitude":5.622101,
     "geom:longitude":-55.29334,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"SR.PR.ND"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880268,
-    "wof:geomhash":"585ccb672617a10c43803863ebfe4a18",
+    "wof:geomhash":"1cce5c9a45de378c46a1d085ef53b393",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091712655,
-    "wof:lastmodified":1566649876,
+    "wof:lastmodified":1695886427,
     "wof:name":"Noord",
     "wof:parent_id":85677319,
     "wof:placetype":"county",

--- a/data/109/171/268/9/1091712689.geojson
+++ b/data/109/171/268/9/1091712689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175572,
-    "geom:area_square_m":2160734279.836148,
+    "geom:area_square_m":2160734157.127412,
     "geom:bbox":"-57.200093,5.275071,-56.700042,5.980417",
     "geom:latitude":5.567218,
     "geom:longitude":-56.929581,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.NI.GH",
         "wd:id":"Q1757533"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880270,
-    "wof:geomhash":"8dea1f5bb75b99646816f106238501eb",
+    "wof:geomhash":"a23e5a0707d6dc93e3f7e9ea5fe6906a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091712689,
-    "wof:lastmodified":1690866696,
+    "wof:lastmodified":1695886485,
     "wof:name":"Groot Henar",
     "wof:parent_id":85677307,
     "wof:placetype":"county",

--- a/data/109/171/272/7/1091712727.geojson
+++ b/data/109/171/272/7/1091712727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134728,
-    "geom:area_square_m":1657886780.68839,
+    "geom:area_square_m":1657886433.162738,
     "geom:bbox":"-55.97905,5.409757,-55.542251,5.88093",
     "geom:latitude":5.634795,
     "geom:longitude":-55.755125,
@@ -87,9 +87,10 @@
         "hasc:id":"SR.SA.CL",
         "wd:id":"Q1120959"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880272,
-    "wof:geomhash":"b88be6f4acdc175d34e4281af4aeabd4",
+    "wof:geomhash":"ff466cc0dc7ac0b48fd06bf41ee582d9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091712727,
-    "wof:lastmodified":1690866696,
+    "wof:lastmodified":1695886483,
     "wof:name":"Calcutta",
     "wof:parent_id":85677341,
     "wof:placetype":"county",

--- a/data/109/171/276/5/1091712765.geojson
+++ b/data/109/171/276/5/1091712765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058943,
-    "geom:area_square_m":726073295.179355,
+    "geom:area_square_m":726073378.710858,
     "geom:bbox":"-55.299945,4.760518,-55.00099,5.141048",
     "geom:latitude":4.991031,
     "geom:longitude":-55.185062,
@@ -147,9 +147,10 @@
         "hasc:id":"SR.BR.BW",
         "wd:id":"Q927447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880273,
-    "wof:geomhash":"0fd0eabf037776dcc0071a9d4bfa52c7",
+    "wof:geomhash":"01c54707f523bbd0fbee2bbf0414cf84",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1091712765,
-    "wof:lastmodified":1690866702,
+    "wof:lastmodified":1695886730,
     "wof:name":"Brownsweg",
     "wof:parent_id":85677313,
     "wof:placetype":"county",

--- a/data/109/171/280/5/1091712805.geojson
+++ b/data/109/171/280/5/1091712805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.621925,
-    "geom:area_square_m":7673002374.715588,
+    "geom:area_square_m":7673002434.724432,
     "geom:bbox":"-56.358689,3.256361,-55.24702,4.572774",
     "geom:latitude":3.820888,
     "geom:longitude":-55.689269,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.SI.BS",
         "wd:id":"Q2582096"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880275,
-    "wof:geomhash":"9c83485576a374ec9aeb12099f520f6f",
+    "wof:geomhash":"55d96a93c3eda6b093d5cf31453f73bc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091712805,
-    "wof:lastmodified":1690866695,
+    "wof:lastmodified":1695886483,
     "wof:name":"Boven Suriname",
     "wof:parent_id":85677323,
     "wof:placetype":"county",

--- a/data/109/171/284/5/1091712845.geojson
+++ b/data/109/171/284/5/1091712845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036997,
-    "geom:area_square_m":455134870.236227,
+    "geom:area_square_m":455134881.773684,
     "geom:bbox":"-54.531157,5.714627,-54.257116,5.881264",
     "geom:latitude":5.794458,
     "geom:longitude":-54.402302,
@@ -90,9 +90,10 @@
         "hasc:id":"SR.MA.WH",
         "wd:id":"Q1318702"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880277,
-    "wof:geomhash":"27ceae310001b07532b98b1b8b0eee38",
+    "wof:geomhash":"dd33f553835e878a6eb03ce0d1ea4958",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091712845,
-    "wof:lastmodified":1690866701,
+    "wof:lastmodified":1695886427,
     "wof:name":"Wanhatti",
     "wof:parent_id":85677317,
     "wof:placetype":"county",

--- a/data/109/171/289/1/1091712891.geojson
+++ b/data/109/171/289/1/1091712891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040418,
-    "geom:area_square_m":497424289.844971,
+    "geom:area_square_m":497424080.494308,
     "geom:bbox":"-54.350946,5.355047,-54.156244,5.737009",
     "geom:latitude":5.565891,
     "geom:longitude":-54.253999,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.MA.MT",
         "wd:id":"Q1757572"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880279,
-    "wof:geomhash":"e988f99cbf1925f316eae4d202efb83c",
+    "wof:geomhash":"46f20d45beea6663c8090b3e6c72fe0d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091712891,
-    "wof:lastmodified":1690866695,
+    "wof:lastmodified":1695886426,
     "wof:name":"Moengotapoe",
     "wof:parent_id":85677317,
     "wof:placetype":"county",

--- a/data/109/171/291/9/1091712919.geojson
+++ b/data/109/171/291/9/1091712919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.295063,
-    "geom:area_square_m":15964682665.802471,
+    "geom:area_square_m":15964682430.683323,
     "geom:bbox":"-57.079071,3.631244,-55.661573,5.539855",
     "geom:latitude":4.461384,
     "geom:longitude":-56.327073,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.SI.BC",
         "wd:id":"Q953434"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880280,
-    "wof:geomhash":"7eef02e440c97cdc2a96de032e5cf59d",
+    "wof:geomhash":"c4ff829fd2076a0eac06b3f142193eba",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091712919,
-    "wof:lastmodified":1690866703,
+    "wof:lastmodified":1695886485,
     "wof:name":"Coppename",
     "wof:parent_id":85677323,
     "wof:placetype":"county",

--- a/data/109/171/296/1/1091712961.geojson
+++ b/data/109/171/296/1/1091712961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004536,
-    "geom:area_square_m":55788200.910799,
+    "geom:area_square_m":55788005.132983,
     "geom:bbox":"-55.179498,5.83625,-55.100418,5.918722",
     "geom:latitude":5.878395,
     "geom:longitude":-55.142421,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.PM.BG",
         "wd:id":"Q1757538"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880282,
-    "wof:geomhash":"b122cb7581e7b1475e0be957bf58708e",
+    "wof:geomhash":"e14d7267cc5ce9595bd37a3ee893569e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091712961,
-    "wof:lastmodified":1690866703,
+    "wof:lastmodified":1695886483,
     "wof:name":"Blauwgrond",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/299/9/1091712999.geojson
+++ b/data/109/171/299/9/1091712999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00016,
-    "geom:area_square_m":1972555.627991,
+    "geom:area_square_m":1972539.678626,
     "geom:bbox":"-55.215811,5.813507,-55.202449,5.831341",
     "geom:latitude":5.822924,
     "geom:longitude":-55.210462,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.PM.FL",
         "wd:id":"Q1757272"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880283,
-    "wof:geomhash":"0b0c6be6a25d1761c62ef661851d0f71",
+    "wof:geomhash":"488a3987ac5a5dec9ed8cfe89857ce57",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091712999,
-    "wof:lastmodified":1690866704,
+    "wof:lastmodified":1695886485,
     "wof:name":"Flora",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/303/7/1091713037.geojson
+++ b/data/109/171/303/7/1091713037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00077,
-    "geom:area_square_m":9476889.120359,
+    "geom:area_square_m":9476826.024095,
     "geom:bbox":"-55.196936,5.776715,-55.159156,5.804026",
     "geom:latitude":5.791917,
     "geom:longitude":-55.178305,
@@ -90,9 +90,10 @@
         "hasc:id":"SR.PM.LV",
         "wd:id":"Q2549349"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880285,
-    "wof:geomhash":"7515e874dbea86743b73ce3c43e6d32c",
+    "wof:geomhash":"45ce821e49a1ed62a3ecd424b6b7f31e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091713037,
-    "wof:lastmodified":1690866700,
+    "wof:lastmodified":1695886427,
     "wof:name":"Livorno",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/307/5/1091713075.geojson
+++ b/data/109/171/307/5/1091713075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00053,
-    "geom:area_square_m":6525701.930637,
+    "geom:area_square_m":6525601.159903,
     "geom:bbox":"-55.243245,5.809686,-55.214717,5.838137",
     "geom:latitude":5.824394,
     "geom:longitude":-55.227634,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.PM.TG",
         "wd:id":"Q956753"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880287,
-    "wof:geomhash":"b989f708df8369f3573ec13bbf2f972f",
+    "wof:geomhash":"703d04894aabfc59f71e9bfc44591883",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091713075,
-    "wof:lastmodified":1690866693,
+    "wof:lastmodified":1695886486,
     "wof:name":"Tammenga",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/311/7/1091713117.geojson
+++ b/data/109/171/311/7/1091713117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003144,
-    "geom:area_square_m":38667038.13797,
+    "geom:area_square_m":38667173.22012,
     "geom:bbox":"-55.258546,5.84808,-55.201586,5.925109",
     "geom:latitude":5.884823,
     "geom:longitude":-55.231956,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.PM.WS",
         "wd:id":"Q587993"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880288,
-    "wof:geomhash":"9a0f6abfa3f6ddaf0aa6c3cf33c273db",
+    "wof:geomhash":"6ad5039d0e21601716e589f82a1e2434",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091713117,
-    "wof:lastmodified":1690866704,
+    "wof:lastmodified":1695886486,
     "wof:name":"Weg Naar Zee",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/315/7/1091713157.geojson
+++ b/data/109/171/315/7/1091713157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001774,
-    "geom:area_square_m":21817682.695422,
+    "geom:area_square_m":21818070.247276,
     "geom:bbox":"-55.198435,5.829692,-55.150808,5.912981",
     "geom:latitude":5.870967,
     "geom:longitude":-55.181083,
@@ -75,9 +75,10 @@
         "hasc:id":"SR.PM.RA",
         "wd:id":"Q691495"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880290,
-    "wof:geomhash":"577da9e148228babe723c721367bbafd",
+    "wof:geomhash":"1cee5fba28ed24bb9754148004b5e060",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091713157,
-    "wof:lastmodified":1627522789,
+    "wof:lastmodified":1695886485,
     "wof:name":"Rainville",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/318/7/1091713187.geojson
+++ b/data/109/171/318/7/1091713187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000793,
-    "geom:area_square_m":9755070.161723,
+    "geom:area_square_m":9754859.08631,
     "geom:bbox":"-55.211363,5.848474,-55.193556,5.911524",
     "geom:latitude":5.880636,
     "geom:longitude":-55.202098,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.PM.MU",
         "wd:id":"Q2577730"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880291,
-    "wof:geomhash":"489551401dad9e1468f016a5909d1139",
+    "wof:geomhash":"28bb4f413c29dbe0481f7ed498d32c18",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091713187,
-    "wof:lastmodified":1690866704,
+    "wof:lastmodified":1695886428,
     "wof:name":"Munder",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/321/9/1091713219.geojson
+++ b/data/109/171/321/9/1091713219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000472,
-    "geom:area_square_m":5800465.143716,
+    "geom:area_square_m":5800335.535582,
     "geom:bbox":"-55.237549,5.830825,-55.201919,5.848544",
     "geom:latitude":5.840752,
     "geom:longitude":-55.218258,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"SR.PM.WG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880292,
-    "wof:geomhash":"f956e67cc23b4b0716ba6a94e9a9a0c5",
+    "wof:geomhash":"44fe32c736fa135db8c7dec2615d6aa6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091713219,
-    "wof:lastmodified":1627522790,
+    "wof:lastmodified":1695886486,
     "wof:name":"Welgelegen",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/326/3/1091713263.geojson
+++ b/data/109/171/326/3/1091713263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00094,
-    "geom:area_square_m":11566397.983644,
+    "geom:area_square_m":11566370.253604,
     "geom:bbox":"-55.205732,5.812667,-55.163498,5.84936",
     "geom:latitude":5.828976,
     "geom:longitude":-55.186545,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"SR.PM.CP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880294,
-    "wof:geomhash":"84081069a090afa76709a4285fa041ac",
+    "wof:geomhash":"7e61a2e4562b6a3b2d96478e475fe099",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091713263,
-    "wof:lastmodified":1627522788,
+    "wof:lastmodified":1695886483,
     "wof:name":"Centrum",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/329/5/1091713295.geojson
+++ b/data/109/171/329/5/1091713295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000436,
-    "geom:area_square_m":5368290.766742,
+    "geom:area_square_m":5368412.218793,
     "geom:bbox":"-55.208916,5.803639,-55.165125,5.822194",
     "geom:latitude":5.811062,
     "geom:longitude":-55.187504,
@@ -84,9 +84,10 @@
         "hasc:id":"SR.PM.BH",
         "wd:id":"Q1757528"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880295,
-    "wof:geomhash":"2dd25d69d486c4b45aa527698c3536f5",
+    "wof:geomhash":"df136fd12ff4d6fa50151690e7a94045",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091713295,
-    "wof:lastmodified":1690866704,
+    "wof:lastmodified":1695886483,
     "wof:name":"Beekhuizen",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/333/3/1091713333.geojson
+++ b/data/109/171/333/3/1091713333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002891,
-    "geom:area_square_m":35568119.96085,
+    "geom:area_square_m":35568031.109813,
     "geom:bbox":"-55.253287,5.72569,-55.191981,5.789158",
     "geom:latitude":5.760028,
     "geom:longitude":-55.222992,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.WA.NG",
         "wd:id":"Q1978021"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880297,
-    "wof:geomhash":"24fd20d38ea27b7f3941c18bed973ae5",
+    "wof:geomhash":"fb5eae81b650c9d6cb1d15602252f069",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091713333,
-    "wof:lastmodified":1627522789,
+    "wof:lastmodified":1695886485,
     "wof:name":"De Nieuwe Grond",
     "wof:parent_id":85677347,
     "wof:placetype":"county",

--- a/data/109/171/337/5/1091713375.geojson
+++ b/data/109/171/337/5/1091713375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000529,
-    "geom:area_square_m":6506866.859992,
+    "geom:area_square_m":6507040.025879,
     "geom:bbox":"-55.239932,5.779772,-55.191131,5.799239",
     "geom:latitude":5.791382,
     "geom:longitude":-55.213232,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.PM.PB",
         "wd:id":"Q2280468"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880298,
-    "wof:geomhash":"a01a3982d6acce75d48dcd0a42e3f90b",
+    "wof:geomhash":"b13f21aa89ae5202c957840559f73ef5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091713375,
-    "wof:lastmodified":1690866694,
+    "wof:lastmodified":1695886426,
     "wof:name":"Pontbuiten",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/341/7/1091713417.geojson
+++ b/data/109/171/341/7/1091713417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00047,
-    "geom:area_square_m":5776070.504631,
+    "geom:area_square_m":5776142.531384,
     "geom:bbox":"-55.23012,5.794,-55.194423,5.813576",
     "geom:latitude":5.805145,
     "geom:longitude":-55.212177,
@@ -87,9 +87,10 @@
         "hasc:id":"SR.PM.LT",
         "wd:id":"Q2352515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880300,
-    "wof:geomhash":"37b851c6eb900f74b81a80adb57fc7bd",
+    "wof:geomhash":"37a626758c0c05151ad7ec87f8d5d30e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091713417,
-    "wof:lastmodified":1690866698,
+    "wof:lastmodified":1695886485,
     "wof:name":"Latour",
     "wof:parent_id":85677337,
     "wof:placetype":"county",

--- a/data/109/171/343/5/1091713435.geojson
+++ b/data/109/171/343/5/1091713435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005378,
-    "geom:area_square_m":66162218.168629,
+    "geom:area_square_m":66162218.168633,
     "geom:bbox":"-55.3351535348,5.73914096963,-55.2284337253,5.82147072778",
     "geom:latitude":5.779633,
     "geom:longitude":-55.280562,
@@ -78,9 +78,10 @@
         "hasc:id":"SR.WA.KO",
         "wd:id":"Q1757514"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880301,
-    "wof:geomhash":"f25709caf1ee3bf4e93b16ce02ece560",
+    "wof:geomhash":"228e1a93e8a28444990997a7f5a2831c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091713435,
-    "wof:lastmodified":1566649879,
+    "wof:lastmodified":1695886428,
     "wof:name":"Koewarasan",
     "wof:parent_id":85677347,
     "wof:placetype":"county",

--- a/data/109/171/347/1/1091713471.geojson
+++ b/data/109/171/347/1/1091713471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.174135,
-    "geom:area_square_m":39175312361.490662,
+    "geom:area_square_m":39175312804.251495,
     "geom:bbox":"-56.181121,2.316707,-53.978763,5.382943",
     "geom:latitude":3.437542,
     "geom:longitude":-54.950817,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.SI.TP",
         "wd:id":"Q2981014"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880302,
-    "wof:geomhash":"6907626c06914356b28f3a5d395f7cf5",
+    "wof:geomhash":"56f9bb62f093a9756daff4e8f269c51a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091713471,
-    "wof:lastmodified":1690866699,
+    "wof:lastmodified":1695886486,
     "wof:name":"Tapanahony",
     "wof:parent_id":85677323,
     "wof:placetype":"county",

--- a/data/109/171/351/7/1091713517.geojson
+++ b/data/109/171/351/7/1091713517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.548723,
-    "geom:area_square_m":19126686349.448544,
+    "geom:area_square_m":19126686679.93396,
     "geom:bbox":"-57.701542,1.837306,-55.900986,3.778172",
     "geom:latitude":2.803318,
     "geom:longitude":-56.599077,
@@ -81,9 +81,10 @@
         "hasc:id":"SR.SI.CO",
         "wd:id":"Q2785517"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880304,
-    "wof:geomhash":"6fd561af2e09fd4ea13156b09158f0c7",
+    "wof:geomhash":"fc12b15ce490c935b05fb86e200c833a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091713517,
-    "wof:lastmodified":1690866701,
+    "wof:lastmodified":1695886483,
     "wof:name":"Coeroeni",
     "wof:parent_id":85677323,
     "wof:placetype":"county",

--- a/data/109/171/354/3/1091713543.geojson
+++ b/data/109/171/354/3/1091713543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016702,
-    "geom:area_square_m":205412873.738962,
+    "geom:area_square_m":205413138.680795,
     "geom:bbox":"-55.158779,5.871119,-54.960087,6.016639",
     "geom:latitude":5.957184,
     "geom:longitude":-55.055622,
@@ -84,9 +84,10 @@
         "hasc:id":"SR.CM.MG",
         "wd:id":"Q1757284"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SR",
     "wof:created":1473880306,
-    "wof:geomhash":"b0ecd19359c7cff5794f6becaf5c99fa",
+    "wof:geomhash":"874792bbefcf946aab7add09a509aa87",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091713543,
-    "wof:lastmodified":1690866694,
+    "wof:lastmodified":1695886426,
     "wof:name":"Margaretha",
     "wof:parent_id":85677329,
     "wof:placetype":"county",

--- a/data/856/324/43/85632443.geojson
+++ b/data/856/324/43/85632443.geojson
@@ -1137,6 +1137,7 @@
         "hasc:id":"SR",
         "icao:code":"PZ",
         "ioc:id":"SUR",
+        "iso:code":"SR",
         "itu:id":"SUR",
         "loc:id":"n79022986",
         "m49:code":"740",
@@ -1151,6 +1152,7 @@
         "wk:page":"Suriname",
         "wmo:id":"SM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:country_alpha3":"SUR",
     "wof:geom_alt":[
@@ -1173,7 +1175,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1694639667,
+    "wof:lastmodified":1695881327,
     "wof:name":"Suriname",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/773/07/85677307.geojson
+++ b/data/856/773/07/85677307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.423333,
-    "geom:area_square_m":5209459438.493284,
+    "geom:area_square_m":5209458877.067164,
     "geom:bbox":"-57.339381,5.220251,-56.453003,6.006778",
     "geom:latitude":5.61391,
     "geom:longitude":-56.885684,
@@ -284,17 +284,19 @@
         "gn:id":3383438,
         "gp:id":2346410,
         "hasc:id":"SR.NI",
+        "iso:code":"SR-NI",
         "iso:id":"SR-NI",
         "qs_pg:id":219583,
         "unlc:id":"SR-NI",
         "wd:id":"Q1147515",
         "wk:page":"Nickerie District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc40544499b72d31c2f2d8392c8a8bda",
+    "wof:geomhash":"722d0e057efd9664f67c7a3749fd3c33",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866691,
+    "wof:lastmodified":1695884850,
     "wof:name":"Nickerie",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/13/85677313.geojson
+++ b/data/856/773/13/85677313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.597748,
-    "geom:area_square_m":7365596828.795917,
+    "geom:area_square_m":7365596974.93603,
     "geom:bbox":"-55.518358,4.014834,-54.728048,5.367643",
     "geom:latitude":4.76598,
     "geom:longitude":-55.114305,
@@ -289,17 +289,19 @@
         "gn:id":3384481,
         "gp:id":2346406,
         "hasc:id":"SR.BR",
+        "iso:code":"SR-BR",
         "iso:id":"SR-BR",
         "qs_pg:id":423844,
         "unlc:id":"SR-BR",
         "wd:id":"Q847680",
         "wk:page":"Brokopondo District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d7af0815d8858d20dec9b6f1e7a4571f",
+    "wof:geomhash":"3314bdbc453f2a920709122bd39c55e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866692,
+    "wof:lastmodified":1695884851,
     "wof:name":"Brokopondo",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/17/85677317.geojson
+++ b/data/856/773/17/85677317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.389005,
-    "geom:area_square_m":4786936772.769646,
+    "geom:area_square_m":4786936550.314844,
     "geom:bbox":"-54.734963,5.227997,-53.982887,5.979249",
     "geom:latitude":5.625227,
     "geom:longitude":-54.362971,
@@ -283,17 +283,19 @@
         "gn:id":3383560,
         "gp:id":2346409,
         "hasc:id":"SR.MA",
+        "iso:code":"SR-MA",
         "iso:id":"SR-MA",
         "qs_pg:id":984093,
         "unlc:id":"SR-MA",
         "wd:id":"Q1140897",
         "wk:page":"Marowijne District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"462603641d5d0246220bbaf5d6babeee",
+    "wof:geomhash":"d04c22f20e794708af22dc548f93dcb2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -308,7 +310,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866690,
+    "wof:lastmodified":1695884850,
     "wof:name":"Marowijne",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/19/85677319.geojson
+++ b/data/856/773/19/85677319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.442575,
-    "geom:area_square_m":5448676221.772029,
+    "geom:area_square_m":5448676080.488637,
     "geom:bbox":"-56.045398,4.99462,-54.623314,5.703869",
     "geom:latitude":5.349837,
     "geom:longitude":-55.334897,
@@ -286,17 +286,19 @@
         "gn:id":3383337,
         "gp:id":2346411,
         "hasc:id":"SR.PR",
+        "iso:code":"SR-PR",
         "iso:id":"SR-PR",
         "qs_pg:id":1135203,
         "unlc:id":"SR-PR",
         "wd:id":"Q1140891",
         "wk:page":"Para District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c6a79e8273a085da75f9720b2bf12a49",
+    "wof:geomhash":"b877db18e21a0638fa40bfdeb6358c9f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866691,
+    "wof:lastmodified":1695884850,
     "wof:name":"Para",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/23/85677323.geojson
+++ b/data/856/773/23/85677323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.16884,
-    "geom:area_square_m":113118426322.852722,
+    "geom:area_square_m":113118426729.585129,
     "geom:bbox":"-58.070506,1.837306,-53.978763,5.539855",
     "geom:latitude":3.762182,
     "geom:longitude":-56.028275,
@@ -286,17 +286,19 @@
         "gn:id":3383062,
         "gp:id":2346414,
         "hasc:id":"SR.SI",
+        "iso:code":"SR-SI",
         "iso:id":"SR-SI",
         "qs_pg:id":890089,
         "unlc:id":"SR-SI",
         "wd:id":"Q1130138",
         "wk:page":"Sipaliwini District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"14156ff338e07f2da2096d274ff014be",
+    "wof:geomhash":"bdce6ba51b0b8431f8bf86c182a51cb3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866692,
+    "wof:lastmodified":1695884850,
     "wof:name":"Sipaliwini",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/29/85677329.geojson
+++ b/data/856/773/29/85677329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198207,
-    "geom:area_square_m":2438500989.141311,
+    "geom:area_square_m":2438500789.604254,
     "geom:bbox":"-55.158779,5.485897,-54.621101,6.016639",
     "geom:latitude":5.755301,
     "geom:longitude":-54.894898,
@@ -286,17 +286,19 @@
         "gn:id":3384418,
         "gp:id":2346407,
         "hasc:id":"SR.CM",
+        "iso:code":"SR-CM",
         "iso:id":"SR-CM",
         "qs_pg:id":219582,
         "unlc:id":"SR-CM",
         "wd:id":"Q952510",
         "wk:page":"Commewijne District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dfecf1bb43a4bb24a3ccc0c23d2b0cd5",
+    "wof:geomhash":"fe8c2d84b111b8629f3d0f848cbb040d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866690,
+    "wof:lastmodified":1695884850,
     "wof:name":"Commewijne",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/33/85677333.geojson
+++ b/data/856/773/33/85677333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.305878,
-    "geom:area_square_m":3763805655.130548,
+    "geom:area_square_m":3763805639.314981,
     "geom:bbox":"-56.603132,5.337658,-55.887085,5.955738",
     "geom:latitude":5.658289,
     "geom:longitude":-56.276327,
@@ -291,17 +291,19 @@
         "gn:id":3384397,
         "gp:id":2346408,
         "hasc:id":"SR.CR",
+        "iso:code":"SR-CR",
         "iso:id":"SR-CR",
         "qs_pg:id":583028,
         "unlc:id":"SR-CR",
         "wd:id":"Q1130141",
         "wk:page":"Coronie District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f2f5991401d552fa5ca1e155f8189137",
+    "wof:geomhash":"deb96095fbb5fc885ecf983b9fb668f6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866690,
+    "wof:lastmodified":1695884850,
     "wof:name":"Coronie",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/37/85677337.geojson
+++ b/data/856/773/37/85677337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014554,
-    "geom:area_square_m":179021229.733011,
+    "geom:area_square_m":179021345.025791,
     "geom:bbox":"-55.258546,5.776715,-55.100418,5.925109",
     "geom:latitude":5.859887,
     "geom:longitude":-55.186963,
@@ -271,12 +271,14 @@
         "gn:id":3383329,
         "gp:id":2346412,
         "hasc:id":"SR.PM",
+        "iso:code":"SR-PM",
         "iso:id":"SR-PM",
         "qs_pg:id":890088,
         "unlc:id":"SR-PM",
         "wd:id":"Q1130134",
         "wk:page":"Paramaribo District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890444597
     ],
@@ -284,7 +286,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"71edf5355bb850a5b1ae3c99c6e659a5",
+    "wof:geomhash":"24850e335250fb3ffaceca372957256c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -299,7 +301,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866691,
+    "wof:lastmodified":1695884851,
     "wof:name":"Paramaribo",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/41/85677341.geojson
+++ b/data/856/773/41/85677341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.304442,
-    "geom:area_square_m":3745745604.715799,
+    "geom:area_square_m":3745745168.430577,
     "geom:bbox":"-55.97905,5.409757,-55.298017,5.999306",
     "geom:latitude":5.717797,
     "geom:longitude":-55.632588,
@@ -292,17 +292,19 @@
         "gn:id":3383110,
         "gp:id":2346413,
         "hasc:id":"SR.SA",
+        "iso:code":"SR-SA",
         "iso:id":"SR-SA",
         "qs_pg:id":423850,
         "unlc:id":"SR-SA",
         "wd:id":"Q1351157",
         "wk:page":"Saramacca District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9c03c22d364e7fca03d73d0d8d55054",
+    "wof:geomhash":"951494105f8e7b7be1575db2ee4a11b1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866691,
+    "wof:lastmodified":1695884851,
     "wof:name":"Saramacca",
     "wof:parent_id":85632443,
     "wof:placetype":"region",

--- a/data/856/773/47/85677347.geojson
+++ b/data/856/773/47/85677347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034918,
-    "geom:area_square_m":429584767.933605,
+    "geom:area_square_m":429584898.877622,
     "geom:bbox":"-55.357816,5.659633,-55.077664,5.945942",
     "geom:latitude":5.759303,
     "geom:longitude":-55.243799,
@@ -286,17 +286,19 @@
         "gn:id":3382761,
         "gp:id":2346415,
         "hasc:id":"SR.WA",
+        "iso:code":"SR-WA",
         "iso:id":"SR-WA",
         "qs_pg:id":479618,
         "unlc:id":"SR-WA",
         "wd:id":"Q1147524",
         "wk:page":"Wanica District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b512c0110105a0a81f64126c209dd03f",
+    "wof:geomhash":"bf4e0f149be0613917d47d85af9b8b75",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "nld"
     ],
-    "wof:lastmodified":1690866692,
+    "wof:lastmodified":1695884851,
     "wof:name":"Wanica",
     "wof:parent_id":85632443,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.